### PR TITLE
refactored priorityOptions source

### DIFF
--- a/src/app/components/todo/Task.tsx
+++ b/src/app/components/todo/Task.tsx
@@ -1,4 +1,4 @@
-import { createPriorityMap } from '@/app/constants/todo/constants'
+import { priorityMap } from '@/app/constants/todo/constants'
 
 interface TaskProps {
 	taskData: Task
@@ -7,18 +7,12 @@ interface TaskProps {
 const Task = ({
 	taskData: { taskName, description, id, priority, completed, createdAt },
 }: TaskProps) => {
-	function getPriority() {
-		// something here should be memoized with useMemo to prevent
-		// recalculated this static object on every render
-		const priorityMap = createPriorityMap()
-		return priorityMap[priority]
-	}
 
 	return (
 		<li className="p-5 bg-lightBlue rounded-md">
 			<h3 className="text-lg font-bold">{taskName}</h3>
 			<p>{description}</p>
-			<p>{getPriority()}</p>
+			<p>{priorityMap.get(priority)}</p>
 			{/* <p>{completed.toString()}</p> */}
 			<p>{createdAt}</p>
 		</li>

--- a/src/app/constants/todo/constants.ts
+++ b/src/app/constants/todo/constants.ts
@@ -1,28 +1,12 @@
-export const priorityOptions: PriorityOption[] = [
-	{
-		label: 'High',
-		value: 3,
-	},
-	{
-		label: 'Medium',
-		value: 2,
-	},
-	{
-		label: 'Low',
-		value: 1,
-	},
-]
+export const priorityMap = new Map([
+	[1, 'Low'],
+	[2, 'Medium'],
+	[3, 'High'],
+]) 
+// here we format data into Map data type
+// I chose a Map because it was easy to convert into 
+// either an array of objects or an object itself
 
-// export const priorityOptionsMap: { [key: number]: string } = {
-// 	1: 'Low',
-// 	2: 'Medium',
-// 	3: 'High',
-// }
-
-export function createPriorityMap() {
-	const map: { [key: number]: string } = {}
-	priorityOptions.forEach((item: PriorityOption) => {
-		map[item.value] = item.label
-	})
-	return map
-}
+export const priorityOptions = Array.from(priorityMap, ([value, label]) => ({ value, label }))
+// This (single line yay!) creates an array of objects with 
+// a value and label like we originally had on the Todo page


### PR DESCRIPTION
I think I found a way to simplify what we were trying to do earlier with the `priorityOptions`

This potential solution utilizes a `Map` from the new ES6 JS data types. (docs [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)

Essentially, I created a `Map` that will hold all of our options in pairs of `[num, string]`.
From here, we can easily create an Array of objects like before:
`const priorityOptions = Array.from(priorityMap, ([value, label]) => ({ value, label }))`

And we can also reference indexes from the Map like so:
`priorityMap.get(priority)`
Maps have a .get() method that accepts an index (our key in this case) and returns the value.

Let me know what you think!
