### PR TITLE
Add user registration | add `_auth.tsx` as auth page layout

### DIFF
--- a/remix/todo-app/app/routes/_auth.login.tsx
+++ b/remix/todo-app/app/routes/_auth.login.tsx
@@ -41,7 +41,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 		})
 	}
 
-	// If no token exists, allow access to register page
+	// If no token exists, allow access to login page
 	return json({ isAuthenticated: false })
 }
 
@@ -50,7 +50,7 @@ export async function action({ request }: ActionFunctionArgs) {
 	const email = formData.get('email')
 	const password = formData.get('password')
 
-	const { data, error } = await supabase.auth.signUp({
+	const { data, error } = await supabase.auth.signInWithPassword({
 		email: String(email),
 		password: String(password),
 	})
@@ -80,7 +80,7 @@ export default function Screen() {
 	return (
 		<Form
 			method="post"
-			className="flex flex-col justify-center items-center bg-primary-400 space-y-10 p-10 w-fit rounded-md"
+			className="flex flex-col justify-center items-center space-y-10"
 		>
 			<TextInput inputName="email" label="Email" required />
 			<TextInput
@@ -89,7 +89,7 @@ export default function Screen() {
 				inputType="password"
 				required
 			/>
-			<Button label="Register" fullWidth />
+			<Button label="Sign In" fullWidth />
 		</Form>
 	)
 }

--- a/remix/todo-app/app/routes/_auth.register.tsx
+++ b/remix/todo-app/app/routes/_auth.register.tsx
@@ -41,7 +41,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 		})
 	}
 
-	// If no token exists, allow access to login page
+	// If no token exists, allow access to register page
 	return json({ isAuthenticated: false })
 }
 
@@ -50,7 +50,7 @@ export async function action({ request }: ActionFunctionArgs) {
 	const email = formData.get('email')
 	const password = formData.get('password')
 
-	const { data, error } = await supabase.auth.signInWithPassword({
+	const { data, error } = await supabase.auth.signUp({
 		email: String(email),
 		password: String(password),
 	})
@@ -80,7 +80,7 @@ export default function Screen() {
 	return (
 		<Form
 			method="post"
-			className="flex flex-col justify-center items-center bg-primary-400 space-y-10 p-10 w-fit rounded-md"
+			className="flex flex-col justify-center items-center space-y-10"
 		>
 			<TextInput inputName="email" label="Email" required />
 			<TextInput
@@ -89,7 +89,7 @@ export default function Screen() {
 				inputType="password"
 				required
 			/>
-			<Button label="Sign In" fullWidth />
+			<Button label="Register" fullWidth />
 		</Form>
 	)
 }

--- a/remix/todo-app/app/routes/_auth.tsx
+++ b/remix/todo-app/app/routes/_auth.tsx
@@ -1,0 +1,15 @@
+import { Outlet, Link } from '@remix-run/react'
+
+export default function Screen() {
+	return (
+		<div className="flex flex-col justify-center items-center p-10 bg-primary-400 w-fit rounded-md">
+			<Outlet />
+			<div>
+				Already have an account? <Link to="/login">Log In</Link>
+			</div>
+			<div>
+				Need to create an account? <Link to="/register">Register</Link>
+			</div>
+		</div>
+	)
+}

--- a/remix/todo-app/app/routes/register.tsx
+++ b/remix/todo-app/app/routes/register.tsx
@@ -1,0 +1,95 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node'
+import { json, redirect } from '@remix-run/node'
+import { Form } from '@remix-run/react'
+import { getSession, sessionStorage, supabase } from '~/services/session.server'
+import Button from '~/components/Button'
+import TextInput from '~/components/TextInput'
+import { createClient } from '@supabase/supabase-js'
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+	const session = await getSession(request)
+	const accessToken = session.get('access_token')
+
+	// If user has an access token, verify it's still valid
+	if (accessToken) {
+		const supabaseClient = createClient(
+			process.env.SUPABASE_URL!,
+			process.env.SUPABASE_ANON!
+		)
+
+		// Set the session to verify the token
+		supabaseClient.auth.setSession({
+			access_token: accessToken,
+			refresh_token: session.get('refresh_token'),
+		})
+
+		const {
+			data: { user },
+			error,
+		} = await supabaseClient.auth.getUser()
+
+		// If token is valid and user exists, redirect to todo page
+		if (!error && user) {
+			return redirect('/todo')
+		}
+
+		// If token is invalid, destroy the session
+		return redirect('/login', {
+			headers: {
+				'Set-Cookie': await sessionStorage.destroySession(session),
+			},
+		})
+	}
+
+	// If no token exists, allow access to register page
+	return json({ isAuthenticated: false })
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+	const formData = await request.formData()
+	const email = formData.get('email')
+	const password = formData.get('password')
+
+	const { data, error } = await supabase.auth.signUp({
+		email: String(email),
+		password: String(password),
+	})
+
+	if (error) {
+		return json({ error: error.message })
+	}
+
+	if (data?.session) {
+		// Create new session
+		const session = await sessionStorage.getSession()
+		session.set('access_token', data.session.access_token)
+		session.set('refresh_token', data.session.refresh_token)
+		session.set('user_id', data.session.user.id)
+
+		return redirect('/todo', {
+			headers: {
+				'Set-Cookie': await sessionStorage.commitSession(session),
+			},
+		})
+	}
+
+	return json({ error: 'An unexpected error occurred' })
+}
+
+export default function Screen() {
+	return (
+		<Form
+			method="post"
+			className="flex flex-col justify-center items-center bg-primary-400 space-y-10 p-10 w-fit rounded-md"
+		>
+			<TextInput inputName="email" label="Email" required />
+			<TextInput
+				inputName="password"
+				label="Password"
+				inputType="password"
+				required
+			/>
+			<Button label="Register" fullWidth />
+		</Form>
+	)
+}


### PR DESCRIPTION
We successfully added the ability to register a user account.

We added the `_auth.tsx` nested layout file and applied it to `login.tsx` and `register.tsx` by changing the names of those files to `_auth.login.tsx` and `_auth.register.tsx`. This now wraps the contents of the login and register routes in the contents of the `_auth.tsx` route.

We began to alter the styles of login/register and `_auth.tsx` to allow for the addition of "Already have an account? Log in" and "Need to create an account? Register" links.